### PR TITLE
Added functionality to convert Ansel.Images <> RGB

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -17,7 +17,7 @@ packages = [
   { name = "plug", version = "1.16.1", build_tools = ["mix"], requirements = ["mime", "plug_crypto", "telemetry"], otp_app = "plug", source = "hex", outer_checksum = "A13FF6B9006B03D7E33874945B2755253841B238C34071ED85B0E86057F8CDDC" },
   { name = "plug_crypto", version = "2.1.0", build_tools = ["mix"], requirements = [], otp_app = "plug_crypto", source = "hex", outer_checksum = "131216A4B030B8F8CE0F26038BC4421AE60E4BB95C5CF5395E1421437824C4FA" },
   { name = "simplifile", version = "2.2.0", build_tools = ["gleam"], requirements = ["filepath", "gleam_stdlib"], otp_app = "simplifile", source = "hex", outer_checksum = "0DFABEF7DC7A9E2FF4BB27B108034E60C81BEBFCB7AB816B9E7E18ED4503ACD8" },
-  { name = "snag", version = "0.3.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "snag", source = "hex", outer_checksum = "54D32E16E33655346AA3E66CBA7E191DE0A8793D2C05284E3EFB90AD2CE92BCC" },
+  { name = "snag", version = "1.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "snag", source = "hex", outer_checksum = "7E9F06390040EB5FAB392CE642771484136F2EC103A92AE11BA898C8167E6E17" },
   { name = "table", version = "0.1.2", build_tools = ["mix"], requirements = [], otp_app = "table", source = "hex", outer_checksum = "7E99BC7EFEF806315C7E65640724BF165C3061CDC5D854060F74468367065029" },
   { name = "telemetry", version = "1.3.0", build_tools = ["rebar3"], requirements = [], otp_app = "telemetry", source = "hex", outer_checksum = "7015FC8919DBE63764F4B4B87A95B7C0996BD539E0D499BE6EC9D7F3875B79E6" },
   { name = "vix", version = "0.30.0", build_tools = ["mix", "make"], requirements = ["castore", "cc_precompiler", "elixir_make", "kino"], otp_app = "vix", source = "hex", outer_checksum = "B07E43855C636DE0378BC1730B82ABCAF7DB43C169E7E8C3333AAEDEE7BFDE83" },
@@ -27,5 +27,5 @@ packages = [
 gleam_stdlib = { version = ">= 0.34.0 and < 2.0.0" }
 gleeunit = { version = ">= 1.0.0 and < 2.0.0" }
 simplifile = { version = ">= 2.2.0 and < 3.0.0" }
-snag = { version = ">= 0.3.0 and < 1.0.0" }
+snag = { version = ">= 0.3.0 and < 2.0.0" }
 vix = { version = ">= 0.30.0 and < 1.0.0" }

--- a/src/ansel.ex
+++ b/src/ansel.ex
@@ -18,6 +18,14 @@ defmodule Ansel do
     Image.write_to_stream(image, format) |> Enum.into(<<>>)
   end
 
+  def to_rgb_list(image) do
+    Image.to_list(image)
+  end
+
+  def from_binary(binary, height, width) do
+    Image.new_from_binary(binary, height, width, 3, :VIPS_FORMAT_UCHAR)
+  end
+
   def composite_over(base_image, overlay_image, l, t) do
     Operation.composite2(base_image, overlay_image, :VIPS_BLEND_MODE_OVER, x: l, y: t)
   end

--- a/test/image_test.gleam
+++ b/test/image_test.gleam
@@ -1,6 +1,7 @@
 import ansel/bounding_box
 import ansel/color
 import ansel/image
+import gleam/list
 import gleam/result
 import gleeunit
 import gleeunit/should
@@ -378,5 +379,59 @@ pub fn rotate270_test() {
   |> should.equal(
     simplifile.read_bits("test/resources/rotated_270.png")
     |> result.replace_error(Nil),
+  )
+}
+
+pub fn to_pixel_list_success_test() {
+  image.new(6, 6, color.GleamLucy)
+  |> result.try(image.to_rgb_list)
+  |> should.be_ok
+}
+
+pub fn to_pixel_list_size_test() {
+  image.new(6, 6, color.GleamLucy)
+  |> result.try(image.to_rgb_list)
+  |> result.map(fn(pixel_rows) {
+    #(
+      list.length(pixel_rows),
+      pixel_rows |> list.first |> result.unwrap([]) |> list.length,
+    )
+  })
+  |> should.equal(Ok(#(6, 6)))
+}
+
+pub fn to_pixel_list_value_test() {
+  image.new(6, 6, color.GleamLucy)
+  |> result.try(image.to_rgb_list)
+  |> result.map(fn(pixel_rows) {
+    pixel_rows
+    |> list.all(fn(pixel_row) {
+      pixel_row
+      |> list.all(fn(pixel) { pixel == color.RGB(255, 175, 243) })
+    })
+  })
+  |> should.equal(Ok(True))
+}
+
+pub fn from_pixel_list_success_test() {
+  list.repeat(list.repeat(color.RGB(255, 175, 243), 6), 6)
+  |> image.from_rgb_list
+  |> should.be_ok
+}
+
+pub fn from_pixel_list_success_size_test() {
+  list.repeat(list.repeat(color.RGB(255, 175, 243), 6), 6)
+  |> image.from_rgb_list
+  |> result.map(fn(image) { #(image.get_height(image), image.get_width(image)) })
+  |> should.equal(Ok(#(6, 6)))
+}
+
+pub fn from_pixel_list_success_value_test() {
+  list.repeat(list.repeat(color.RGB(255, 175, 243), 6), 6)
+  |> image.from_rgb_list
+  |> result.map(image.to_bit_array(_, image.PNG))
+  |> should.equal(
+    image.new(6, 6, color.GleamLucy)
+    |> result.map(image.to_bit_array(_, image.PNG)),
   )
 }


### PR DESCRIPTION
 - Added type alias `PixelList`
 - Added `to_rgb_list` + `to_rgb_list_ffi` to allow conversion to RGB list
  - Added `from_rgb_list` + `from_binary_ffi` to all conversion from RGB list back to Ansel image
  - Added relevant pathing in `ansel.ex`
 - Added tests.
 - Updated manifest.toml for updated `snag`.