### PR TITLE
Return written image path from `image.write`

### DIFF
--- a/src/ansel.ex
+++ b/src/ansel.ex
@@ -5,17 +5,17 @@ defmodule Ansel do
     Path.expand(path) |> Image.new_from_file()
   end
 
-  def write_to_file(img, path) do
-    save_path = Path.expand(path)
+  def write_to_file(img, path, {:format_components, extension, options}) do
+    save_path = Path.expand(path <> extension)
 
-    case Image.write_to_file(img, save_path) do
-      :ok -> {:ok, nil}
+    case Image.write_to_file(img, save_path <> options) do
+      :ok -> {:ok, save_path}
       {:error, reason} -> {:error, reason}
     end
   end
 
-  def to_bit_array(image, format) do
-    Image.write_to_stream(image, format) |> Enum.into(<<>>)
+  def to_bit_array(image, {:format_components, extension, options}) do
+    Image.write_to_stream(image, extension <> options) |> Enum.into(<<>>)
   end
 
   def to_rgb_list(image) do

--- a/src/ansel/image.gleam
+++ b/src/ansel/image.gleam
@@ -42,9 +42,11 @@ import snag
 /// own vips binary on the host system to. See the package readme for details.
 /// 
 /// The `Custom` constructor allows for advanced vips save options to be 
-/// used, like `ansel.Custom(".png", "[compression=90,squash=true]")`, refer to the 
-/// [Vix package documentation](https://hexdocs.pm/vix/Vix.Vips.Image.html#write_to_file/2) 
-/// for details.
+/// used as a comma separated list, like `ansel.Custom(".png", "compression=90,squash=true")`,
+/// which is equivalent to the `.png[compression=90,squash=true]` syntax used in vips.
+/// 
+/// You can use the libvips CLI to print a list of all supported options for each image format,
+///  e.g. `vips pngsave`, `vips jpegsave`.
 pub type ImageFormat {
   JPEG(quality: Int, keep_metadata: Bool)
   JPEG2000(quality: Int, keep_metadata: Bool)
@@ -100,7 +102,8 @@ fn image_format_to_string(format: ImageFormat) -> FormatComponents {
     Analyze -> FormatComponents(".analyze", "")
     NIfTI -> FormatComponents(".nii", "")
     DeepZoom -> FormatComponents(".dzi", "")
-    Custom(extension:, format:) -> FormatComponents(extension, format)
+    Custom(extension:, format:) ->
+      FormatComponents(extension, "[" <> format <> "]")
   }
 }
 

--- a/test/image_test.gleam
+++ b/test/image_test.gleam
@@ -3,6 +3,7 @@ import ansel/color
 import ansel/image
 import gleam/list
 import gleam/result
+import gleam/string
 import gleeunit
 import gleeunit/should
 import simplifile
@@ -21,6 +22,26 @@ pub fn read_test() {
 
   image.get_width(img)
   |> should.equal(6)
+}
+
+pub fn write_test() {
+  let path = "test/tmp_write_test_asset"
+
+  let output_path =
+    image.new(5, 5, color.GleamLucy)
+    |> should.be_ok
+    |> image.write(path, image.JPEG(quality: 100, keep_metadata: True))
+    |> should.be_ok()
+
+  string.ends_with(output_path, "jpeg")
+  |> should.be_true()
+
+  image.read(output_path)
+  |> should.be_ok
+  |> image.get_width
+  |> should.equal(5)
+
+  let assert Ok(_) = simplifile.delete(output_path)
 }
 
 pub fn new_solid_grey_test() {

--- a/test/image_test.gleam
+++ b/test/image_test.gleam
@@ -44,6 +44,17 @@ pub fn write_test() {
   let assert Ok(_) = simplifile.delete(output_path)
 }
 
+pub fn custom_options_test() {
+  let assert Ok(reference_image) = image.new(6, 6, color.Grey)
+  let output =
+    reference_image
+    |> image.to_bit_array(image.JPEG(quality: 50, keep_metadata: True))
+
+  reference_image
+  |> image.to_bit_array(image.Custom(".jpeg", "Q=50,strip=false"))
+  |> should.equal(output)
+}
+
 pub fn new_solid_grey_test() {
   let assert Ok(bin) =
     simplifile.read_bits("test/resources/solid_grey_6x6.avif")


### PR DESCRIPTION
Closes #3 

This change returns the path of the image as it was written to disk from the `image.write` function.

As I wanted just the path itself, without the format options appended to it, I had to separate those two out internally.

There are 2 breaking changes to the public API:

* `image.write` returns a `Result(String, Snag)` instead of `Result(Nil, Snag)`
* The `Custom` variant constructor now accepts separate parameters for extension and format options – I thought this made sense because I had to separate the two out internally

A side note: I get 11 failing tests (empty output) before any of my changes here locally, not sure what's up with that, may be that I'm on Elixir 1.18 instead of 1.17